### PR TITLE
Skip unit and integration tests when enabling e2e-tests profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<skipTests>${skip.unit-tests}</skipTests>
 					<includes>
 						<include>**/*Test.java</include>
 					</includes>
@@ -167,6 +168,7 @@
 				<executions>
 					<execution>
 						<configuration>
+							<skipTests>${skip.integration-tests}</skipTests>
 							<includes>
 								<include>**/*ApplicationTests.java</include>
 								<include>**/*IT.java</include>


### PR DESCRIPTION
- Now I correctly used Maven properties in the <properties> section to define key/value pairs that can be referenced in other parts of the POM.
- I made changes in surefire and failsafe plugin configuration: <skipTests>${skip.unit-tests}</skipTests> and <skipTests>${skip.integration-tests}</skipTests> 
- By doing this I ensured that when enabling e2e-tests profile, it skips unit and integration tests as in e2e-tests profile this is set to true  <skip.unit-tests>true</skip.unit-tests>, <skip.integration-tests>true</skip.integration-tests>. 