### PR TITLE
e2e test runs uses real database which is PostgreSQL:when enable e2e profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,28 +362,51 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
+						<groupId>io.fabric8</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.38.1</version>
 						<executions>
 							<execution>
-								<id>reserve-tomcat-port</id>
+								<id>start-postgres</id>
+								<phase>pre-integration-test</phase>
 								<goals>
-									<goal>reserve-network-port</goal>
+									<goal>start</goal>
 								</goals>
-								<phase>process-resources</phase>
-								<configuration>
-									<portNames>
-										<portName>tomcat.http.port</portName>
-									</portNames>
-								</configuration>
+							</execution>
+							<execution>
+								<id>stop-postgres</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<images>
+								<image>
+									<name>postgres:latest</name>
+									<run>
+										<env>
+											<POSTGRES_DB>studentdb</POSTGRES_DB>
+											<POSTGRES_USER>hamza</POSTGRES_USER>
+											<POSTGRES_PASSWORD>postgres</POSTGRES_PASSWORD>
+										</env>
+										<ports>
+											<port>5432:5432</port>
+										</ports>
+										<wait>
+											<log>.*database system is ready to accept connections.*</log>
+											<time>120000</time> <!-- Wait up to 120 seconds -->
+										</wait>
+									</run>
+								</image>
+							</images>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.springframework.boot</groupId>
 						<artifactId>spring-boot-maven-plugin</artifactId>
 						<executions>
-							<!-- Start the web application before running tests -->
 							<execution>
 								<id>pre-integration-test</id>
 								<goals>
@@ -393,8 +416,7 @@
 									<wait>20000</wait>
 									<maxAttempts>10</maxAttempts>
 									<arguments>
-										<argument>
-											--server.port=${tomcat.http.port}</argument>
+										<argument>--server.port=8080</argument>
 									</arguments>
 								</configuration>
 							</execution>
@@ -426,11 +448,6 @@
 								</goals>
 							</execution>
 						</executions>
-						<configuration>
-							<systemPropertyVariables>
-								<server.port>${tomcat.http.port}</server.port>
-							</systemPropertyVariables>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/src/it/test/com/student/AdmissionWebControllerIT.java
+++ b/src/it/test/com/student/AdmissionWebControllerIT.java
@@ -15,11 +15,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.student.model.Admission;
 import com.student.repositories.AdmissionRepository;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("h2")
 class AdmissionWebControllerIT {
 
 	@Autowired

--- a/src/it/test/com/student/StudentAdmissionTddApplicationTests.java
+++ b/src/it/test/com/student/StudentAdmissionTddApplicationTests.java
@@ -2,8 +2,10 @@ package com.student;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("h2")
 class StudentAdmissionTddApplicationTests {
 
 	@Test

--- a/src/it/test/com/student/StudentWebControllerIT.java
+++ b/src/it/test/com/student/StudentWebControllerIT.java
@@ -15,12 +15,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.student.model.Admission;
 import com.student.model.Student;
 import com.student.repositories.StudentRepository;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("h2")
 class StudentWebControllerIT {
 
 	@Autowired

--- a/src/main/resources/application-h2.properties
+++ b/src/main/resources/application-h2.properties
@@ -1,0 +1,6 @@
+# H2 configuration 
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# Default PostgreSQL configuration 
+spring.datasource.url=jdbc:postgresql://localhost:5432/studentdb
+spring.datasource.username=hamza
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
- Added Fabric8 Docker Maven Plugin: to manage PostgreSQL as a Docker container during Maven build.
- Configured the plugin to start and stop the PostgreSQL: Pre-integration-test: Starts the PostgreSQL container and Post-integration-test: Stops the PostgreSQL container.
- Configured Application to Use PostgreSQL as Default Database
- When the e2e profile is enabled, it runs with a real PostgreSQL database, as configured in the application.properties.
- When to run e2e using command line enable profile: mvn clean verify -P e2e-tests
- In eclipse run project Run As > Maven Build.... than in goals: clean verify and in profile field: e2e-tests. 